### PR TITLE
Support for multiple LUNs

### DIFF
--- a/cmd/iscsistart/iscsistart.go
+++ b/cmd/iscsistart/iscsistart.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	targetAddr      = flag.String("addr", "instance-1:3260", "target addr")
+	initiatorName   = flag.String("i", "hostname:iscsi_startup.go", "initiator name")
 	volumeName      = flag.String("volume", "FOO", "volume name")
 	monitorNetlink  = flag.Bool("monitorNetlink", false, "Set to true to monitor netlink socket until killed")
 	teardownSession = flag.Int("teardownSid", -1, "Set to teardown a session")
@@ -28,6 +29,7 @@ func main() {
 	}
 
 	device, err := iscsinl.MountIscsi(
+		iscsinl.WithInitiator(*initiatorName),
 		iscsinl.WithTarget(*targetAddr, *volumeName),
 		iscsinl.WithCmdsMax(uint16(*cmdsMax)),
 		iscsinl.WithQueueDepth(uint16(*queueDepth)),

--- a/cmd/iscsistart/iscsistart.go
+++ b/cmd/iscsistart/iscsistart.go
@@ -28,7 +28,7 @@ func main() {
 		return
 	}
 
-	device, err := iscsinl.MountIscsi(
+	devices, err := iscsinl.MountIscsi(
 		iscsinl.WithInitiator(*initiatorName),
 		iscsinl.WithTarget(*targetAddr, *volumeName),
 		iscsinl.WithCmdsMax(uint16(*cmdsMax)),
@@ -39,5 +39,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Printf("Mounted at dev %v", device)
+	for i := range devices {
+		log.Printf("Mounted at dev %v", devices[i])
+	}
 }


### PR DESCRIPTION
iscsinl currently scans only for LUN with id=1. I thought it would be cool if we could achieve what iscsistart does. iscsistart scans all LUNs with all ids.

Also, with this PR, initiatorName can be passed as an argument.