### PR TITLE
Support multiple LUNs

### DIFF
--- a/cmd/iscsistart/iscsistart.go
+++ b/cmd/iscsistart/iscsistart.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	targetAddr      = flag.String("addr", "instance-1:3260", "target addr")
+	initiatorName   = flag.String("i", "hostname:iscsi_startup.go", "initiator name")
 	volumeName      = flag.String("volume", "FOO", "volume name")
 	monitorNetlink  = flag.Bool("monitorNetlink", false, "Set to true to monitor netlink socket until killed")
 	teardownSession = flag.Int("teardownSid", -1, "Set to teardown a session")
@@ -28,6 +29,7 @@ func main() {
 	}
 
 	device, err := iscsinl.MountIscsi(
+		iscsinl.WithInitiator(*initiatorName),
 		iscsinl.WithTarget(*targetAddr, *volumeName),
 		iscsinl.WithCmdsMax(uint16(*cmdsMax)),
 		iscsinl.WithQueueDepth(uint16(*queueDepth)),

--- a/cmd/iscsistart/iscsistart.go
+++ b/cmd/iscsistart/iscsistart.go
@@ -28,7 +28,7 @@ func main() {
 		return
 	}
 
-	device, err := iscsinl.MountIscsi(
+	devices, err := iscsinl.MountIscsi(
 		iscsinl.WithInitiator(*initiatorName),
 		iscsinl.WithTarget(*targetAddr, *volumeName),
 		iscsinl.WithCmdsMax(uint16(*cmdsMax)),
@@ -39,5 +39,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Printf("Mounted at dev %v", device)
+	for i := range devices {
+		log.Printf("Mounted at dev %v", devices[i])
+	}
 }

--- a/initiator_test.go
+++ b/initiator_test.go
@@ -28,29 +28,33 @@ func TestMain(m *testing.M) {
 func TestMountIscsi(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 
-	device, err := MountIscsi(
+	devices, err := MountIscsi(
+		WithInitiator(os.Getenv("INITIATOR_NAME")),
 		WithTarget(fmt.Sprintf("%s:%s", os.Getenv("TGT_SERVER"), os.Getenv("TGT_PORT")), os.Getenv("TGT_VOLUME")),
 		WithDigests("None"),
 	)
 	if err != nil {
+		log.Println(err)
 		t.Error(err)
 	}
 
-	// Make the mountpoint, and mount it.
-	if err := os.MkdirAll("/mp", 0755); err != nil {
-		t.Fatal(err)
-	}
-	mp, err := mount.TryMount(fmt.Sprintf("/dev/%s1", device), "/mp", 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer mp.Unmount(0) //nolint:errcheck
+	for _, device := range devices {
+		// Make the mountpoint, and mount it.
+		if err := os.MkdirAll("/mp", 0755); err != nil {
+			t.Fatal(err)
+		}
 
-	if err := sh.RunWithLogs("ls", "-l", "/mp"); err != nil {
-		t.Error(err)
-	}
+		mp, err := mount.TryMount(fmt.Sprintf("/dev/%s1", device), "/mp", 0)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if err := mp.Unmount(0); err != nil {
-		t.Error(err)
+		if err := sh.RunWithLogs("ls", "-l", "/mp"); err != nil {
+			t.Error(err)
+		}
+
+		if err := mp.Unmount(0); err != nil {
+			t.Error(err)
+		}
 	}
 }

--- a/netlink.go
+++ b/netlink.go
@@ -84,6 +84,33 @@ const (
 	ISCSI_PARAM_INITIATOR_NAME
 )
 
+var paramToString = map[IscsiParam]string {
+	ISCSI_PARAM_TARGET_NAME: "Target Name",
+	ISCSI_PARAM_INITIATOR_NAME: "Inititator Name",
+	ISCSI_PARAM_MAX_RECV_DLENGTH: "Max Recv DLength",
+	ISCSI_PARAM_MAX_XMIT_DLENGTH: "Max Xmit DLenght",
+	ISCSI_PARAM_FIRST_BURST: "First Burst",
+	ISCSI_PARAM_MAX_BURST: "Max Burst",
+	ISCSI_PARAM_PDU_INORDER_EN: "PDU Inorder EN",
+	ISCSI_PARAM_DATASEQ_INORDER_EN: "Data Seq In Order EN",
+	ISCSI_PARAM_INITIAL_R2T_EN: "Inital R2T EN",
+	ISCSI_PARAM_IMM_DATA_EN: "Immediate Data EN",
+	ISCSI_PARAM_EXP_STATSN: "Exp Statsn",
+	ISCSI_PARAM_HDRDGST_EN: "HDR Digest EN",
+	ISCSI_PARAM_DATADGST_EN: "Data Digest EN",
+	ISCSI_PARAM_PING_TMO: "Ping TMO",
+	ISCSI_PARAM_RECV_TMO: "Recv TMO",
+}
+
+func (p IscsiParam) String() string {
+	val, ok := paramToString[p] 
+	if !ok {
+		return fmt.Sprintf("IscsiParam(%d)", int(p))
+	}
+
+	return val
+}
+
 // IscsiErr iscsi_if.h:enum iscsi_err
 type IscsiErr uint32
 


### PR DESCRIPTION
iscsinl currently scans only for LUN with id=1. I thought it would be cool if we could achieve what iscsistart does. iscsistart scans all LUNs with all ids.

Also, with this PR, initiatorName can be passed as an argument.