### PR TITLE
fix session type

### DIFF
--- a/initiator.go
+++ b/initiator.go
@@ -635,6 +635,10 @@ func (s *IscsiTargetSession) Login() error {
 		}
 		hton48(&loginReq.Header.Isid, int(s.sid))
 		loginReq.AddParam("AuthMethod=None")
+		// RFC 3720 page 36 last line, https://tools.ietf.org/html/rfc3720#page-36
+		// The session type is defined during login with the key=value parameter
+		// in the login command.
+		loginReq.AddParam("SessionType=Normal")
 		loginReq.AddParam(fmt.Sprintf("InitiatorName=%s", s.opts.InitiatorName))
 		loginReq.AddParam(fmt.Sprintf("TargetName=%s", s.opts.Volume))
 

--- a/netlink.go
+++ b/netlink.go
@@ -84,26 +84,26 @@ const (
 	ISCSI_PARAM_INITIATOR_NAME
 )
 
-var paramToString = map[IscsiParam]string {
-	ISCSI_PARAM_TARGET_NAME: "Target Name",
-	ISCSI_PARAM_INITIATOR_NAME: "Inititator Name",
-	ISCSI_PARAM_MAX_RECV_DLENGTH: "Max Recv DLength",
-	ISCSI_PARAM_MAX_XMIT_DLENGTH: "Max Xmit DLenght",
-	ISCSI_PARAM_FIRST_BURST: "First Burst",
-	ISCSI_PARAM_MAX_BURST: "Max Burst",
-	ISCSI_PARAM_PDU_INORDER_EN: "PDU Inorder EN",
+var paramToString = map[IscsiParam]string{
+	ISCSI_PARAM_TARGET_NAME:        "Target Name",
+	ISCSI_PARAM_INITIATOR_NAME:     "Initiator Name",
+	ISCSI_PARAM_MAX_RECV_DLENGTH:   "Max Recv DLength",
+	ISCSI_PARAM_MAX_XMIT_DLENGTH:   "Max Xmit DLenght",
+	ISCSI_PARAM_FIRST_BURST:        "First Burst",
+	ISCSI_PARAM_MAX_BURST:          "Max Burst",
+	ISCSI_PARAM_PDU_INORDER_EN:     "PDU Inorder EN",
 	ISCSI_PARAM_DATASEQ_INORDER_EN: "Data Seq In Order EN",
-	ISCSI_PARAM_INITIAL_R2T_EN: "Inital R2T EN",
-	ISCSI_PARAM_IMM_DATA_EN: "Immediate Data EN",
-	ISCSI_PARAM_EXP_STATSN: "Exp Statsn",
-	ISCSI_PARAM_HDRDGST_EN: "HDR Digest EN",
-	ISCSI_PARAM_DATADGST_EN: "Data Digest EN",
-	ISCSI_PARAM_PING_TMO: "Ping TMO",
-	ISCSI_PARAM_RECV_TMO: "Recv TMO",
+	ISCSI_PARAM_INITIAL_R2T_EN:     "Inital R2T EN",
+	ISCSI_PARAM_IMM_DATA_EN:        "Immediate Data EN",
+	ISCSI_PARAM_EXP_STATSN:         "Exp Statsn",
+	ISCSI_PARAM_HDRDGST_EN:         "HDR Digest EN",
+	ISCSI_PARAM_DATADGST_EN:        "Data Digest EN",
+	ISCSI_PARAM_PING_TMO:           "Ping TMO",
+	ISCSI_PARAM_RECV_TMO:           "Recv TMO",
 }
 
 func (p IscsiParam) String() string {
-	val, ok := paramToString[p] 
+	val, ok := paramToString[p]
 	if !ok {
 		return fmt.Sprintf("IscsiParam(%d)", int(p))
 	}


### PR DESCRIPTION
From RFC 3720 page 36 last line, https://tools.ietf.org/html/rfc3720#page-36

The session type is defined during login with the key=value parameter
in the login command.

It seems session type needs to be set in the security negotiation phase. 


