### PR TITLE
Refactor Login sequence

### DIFF
--- a/initiator.go
+++ b/initiator.go
@@ -698,9 +698,6 @@ func (s *IscsiTargetSession) Login() error {
 	log.Println("login: param negotiation")
 
 	queue = append(queue, []string{
-		fmt.Sprintf("InitiatorName=%s", s.opts.InitiatorName),
-		fmt.Sprintf("TargetName=%s", s.opts.Volume),
-		"SessionType=Normal",
 		fmt.Sprintf("MaxRecvDataSegmentLength=%d", s.opts.MaxRecvDLength),
 		fmt.Sprintf("FirstBurstLength=%d", s.opts.FirstBurstLength),
 		fmt.Sprintf("MaxBurstLength=%d", s.opts.MaxBurstLength),


### PR DESCRIPTION
When trying to get this to work with the iSCSI target provided by RHEL8, I found three issues with the Login sequence:
1. we re-transmit parameters. this is an RFC violation (and some targets really don't like it);
2. we don't interpret the three basic param responses. There's a catch for Reject, but not NotUnderstood or Irrelevant.  If we get a NotUnderstood we generally try to decode it as, say, an Int, and fail (note: we get lots of NotUnderstoods due to 1);
3. we have no mechanism to handle requests the target makes of us, which can cause login to fail for trivial reasons.

I handled these three by:
- Using a param queue to control which params have been sent, and dynamically add params that are needed.
- Adding some very basic handling for NotUnderstood and Irrelevant (basically, just ignore them and print a message).
- If we get a param request from the target, blindly mirror it back to accept it (probably not the best long-term strategy, but seems to work).

With these changes, I was able to mount a RHEL8 target.  